### PR TITLE
Remove empty format precision specifier

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -189,7 +189,7 @@ fn main() {
             exit(EXIT_UNABLE_TO_CALCULATE);
         })
         .unwrap();
-    println!("Приближённое значение интеграла: {:.}", result);
+    println!("Приближённое значение интеграла: {}", result);
     let result_for_inaccuracy = calculate_integral_async(
         function,
         lower_bound,
@@ -201,13 +201,13 @@ fn main() {
             exit(EXIT_UNABLE_TO_CALCULATE);
         })
         .unwrap();
-    println!("\"Действительное\" значение интеграла: {:.}", result_for_inaccuracy);
+    println!("\"Действительное\" значение интеграла: {}", result_for_inaccuracy);
     let absolute_inaccuracy = (result_for_inaccuracy - result).abs();
     let relative_incaccuracy = absolute_inaccuracy / result;
     let step = (upper_bound - lower_bound) / samples as f64;
-    println!("Абсолютная погрешность: {:.}", absolute_inaccuracy);
+    println!("Абсолютная погрешность: {}", absolute_inaccuracy);
     let remaining_term_max = get_remaining_term(second_derivative, lower_bound, upper_bound, step);
-    println!("Верхняя граница для Rn: {:.}", remaining_term_max);
-    println!("Абсолютная погрешность соответствует остаточному члену: {:.}", absolute_inaccuracy <= remaining_term_max);
-    println!("Относительная погрешность: {:.}%", relative_incaccuracy * 100.0);
+    println!("Верхняя граница для Rn: {}", remaining_term_max);
+    println!("Абсолютная погрешность соответствует остаточному члену: {}", absolute_inaccuracy <= remaining_term_max);
+    println!("Относительная погрешность: {}%", relative_incaccuracy * 100.0);
 }


### PR DESCRIPTION
A format precision specifier consisting of a dot and no number actually does nothing and has no specified meaning. Currently this is silently ignored, but it may turn into a warning or error.

See https://github.com/rust-lang/rust/issues/131159 and https://github.com/rust-lang/rust/pull/136638

Please leave a comment there if you have any opinion about this. If you remember why this was written this way that could help improve the diagnostics rustc gives.